### PR TITLE
Added formats to not pad months, hours and minutes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ install:
 - sudo apt-get -qq install gcc-4.9 g++-4.9
 - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.9 90
 - sudo update-alternatives --install /usr/bin/gcov gcov /usr/bin/gcov-4.9 90
-- sudo apt-get -qq install perl
 - sudo apt-get -qq install libtest-simple-perl
 - sudo apt-get -qq install libtest-harness-perl
 - sudo apt-get -qq install libdatetime-perl

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,10 @@ install:
 - sudo apt-get -qq install gcc-4.9 g++-4.9
 - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.9 90
 - sudo update-alternatives --install /usr/bin/gcov gcov /usr/bin/gcov-4.9 90
-- sudo apt-get -qq install prove
+- sudo apt-get -qq install perl
+- sudo apt-get -qq install libtest-simple-perl
+- sudo apt-get -qq install libtest-harness-perl
+- sudo apt-get -qq install libdatetime-perl
 # install latest LCOV (1.9 was failing)
 - cd ${TRAVIS_BUILD_DIR}
 - wget http://ftp.de.debian.org/debian/pool/main/l/lcov/lcov_1.11.orig.tar.gz
@@ -33,4 +36,4 @@ before_script:
 script:
 - cd ${TRAVIS_BUILD_DIR}
 # Check that this works this way
-- prove
+- prove -l

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,36 @@
+sudo: required
+dist: trusty
+language: cpp
+compiler:
+- gcc
+before_install:
+# for gcc with C++11 support
+- sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+- sudo apt-get -qq update
+install:
+# install GTest and GMock
+- sudo apt-get -qq install libgtest-dev
+- "cd /usr/src/gtest && sudo cmake . && sudo cmake --build . && sudo mv libg* /usr/local/lib/ ; cd -"
+- sudo apt-get -qq install google-mock
+- "cd /usr/src/gmock && sudo cmake . && sudo cmake --build . && sudo mv libg* /usr/local/lib/ ; cd -"
+# update to gcc with C++11 support
+- sudo apt-get -qq install gcc-4.9 g++-4.9
+- sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.9 90
+- sudo update-alternatives --install /usr/bin/gcov gcov /usr/bin/gcov-4.9 90
+- sudo apt-get -qq install prove
+# install latest LCOV (1.9 was failing)
+- cd ${TRAVIS_BUILD_DIR}
+- wget http://ftp.de.debian.org/debian/pool/main/l/lcov/lcov_1.11.orig.tar.gz
+- tar xf lcov_1.11.orig.tar.gz
+- sudo make -C lcov-1.11/ install
+- gem install coveralls-lcov
+- lcov --version
+- g++ --version
+before_script:
+- cd ${TRAVIS_BUILD_DIR}
+# init coverage to 0 (optional)
+- lcov --directory . --zerocounters
+script:
+- cd ${TRAVIS_BUILD_DIR}
+# Check that this works this way
+- prove

--- a/t/7_misc.t
+++ b/t/7_misc.t
@@ -1,5 +1,5 @@
 
-use Test::More tests => 7;
+use Test::More tests => 20;
 
 use warnings;
 use DateTime;
@@ -44,4 +44,46 @@ is( $strf->format_duration( $duration ), (22*24*60*60) + (36*60*60), '22 days, 3
 
 $strf->set_pattern('%u');
 is( $strf->format_duration( $duration ), '2', '22 days, 36 hours as days modulus 7' );
+
+
+$duration = DateTime::Duration->new( months => 2, days => 2, hours => 30, minutes => 3 );
+$strf->set_normalising(1);
+$strf->set_pattern('%H');
+is( $strf->format_duration( $duration ), '06','format %H 30 - 24 = 06' );
+
+$strf->set_pattern('%-H');
+is( $strf->format_duration( $duration ), '6','format %-H 30 - 24 = 6' );
+
+$strf->set_pattern('%I');
+is( $strf->format_duration( $duration ), '06','format %I 30 - 24 = 06' );
+
+$strf->set_pattern('%-I');
+is( $strf->format_duration( $duration ), '6','format %-I 30 - 24 = 6' );
+
+$strf->set_pattern('%k');
+is( $strf->format_duration( $duration ), ' 6','format %k 30 - 24 =  6' );
+
+$strf->set_pattern('%-k');
+is( $strf->format_duration( $duration ), '6','format %-k 30 - 24 = 6' );
+
+$strf->set_pattern('%l');
+is( $strf->format_duration( $duration ), ' 6','format %l 30 - 24 =  6' );
+
+$strf->set_pattern('%-l');
+is( $strf->format_duration( $duration ), '6','format %-l 30 - 24 = 6' );
+
+$strf->set_pattern('%e');
+is( $strf->format_duration( $duration ), '3','format %e 3 days' );
+
+$strf->set_pattern('%m');
+is( $strf->format_duration( $duration ), '02','format %m 02 months' );
+
+$strf->set_pattern('%-m');
+is( $strf->format_duration( $duration ), '2','format %-m 2 months' );
+
+$strf->set_pattern('%M');
+is( $strf->format_duration( $duration ), '03','format %M 03 minutes' );
+
+$strf->set_pattern('%-M');
+is( $strf->format_duration( $duration ), '3','format %-M 3 minutes' );
 

--- a/t/9_doc_examples.t
+++ b/t/9_doc_examples.t
@@ -1,0 +1,54 @@
+use Test::More tests => 9;
+
+use warnings;
+use DateTime;
+use DateTime::Duration;
+use DateTime::Format::Duration;
+use Data::Dumper;
+
+my $d = DateTime::Format::Duration->new(
+          pattern =>  '%Y years, %-m months, %e days, '.
+                      '%-H hours, %M minutes, %S seconds',
+          normalise => 1
+        );
+
+is($d->format_duration(
+        DateTime::Duration->new(
+          years   => 3,
+          months  => 5,
+          days    => 1,
+          hours   => 6,
+          minutes => 15,
+          seconds => 45,
+          nanoseconds => 12000
+        )
+      ),'3 years, 5 months, 1 days, 6 hours, 15 minutes, 45 seconds','First full format');
+
+  # Returns DateTime::Duration object
+my $duration = $d->parse_duration(
+                    '3 years, 5 months, 1 days, 6 hours, 15 minutes, 45 seconds'
+                );
+
+is($d->format_duration_from_deltas(
+        years   => 3,
+        months  => 5,
+        days    => 1,
+        hours   => 6,
+        minutes => 15,
+        seconds => 45,
+        nanoseconds => 12000
+      ),'3 years, 5 months, 1 days, 6 hours, 15 minutes, 45 seconds',
+  'From deltas');
+
+my %deltas = $d->parse_duration_as_deltas(
+                  '3 years, 5 months, 1 days, 6 hours, 15 minutes, 45 seconds'
+                );
+
+is($deltas{years},3,'3 years');
+is($deltas{months},5,'5 months');
+is($deltas{days},1,'1 days');
+is($deltas{hours},6,'6 hours');
+is($deltas{minutes},15,'15 minutes');
+is($deltas{seconds},45,'45 seconds');
+is($deltas{nanoseconds},0,'0 nanoseconds');
+


### PR DESCRIPTION
Added equilavent Glibc extension to not pad hours, minutes and months with test cases.
See https://rt.cpan.org/Public/Bug/Display.html?id=41843
