### PR TITLE
fix handling of DateTime::* subclasses as base or object-to-format

### DIFF
--- a/lib/DateTime/Format/Duration.pm
+++ b/lib/DateTime/Format/Duration.pm
@@ -9,6 +9,7 @@ use DateTime::Duration;
 use constant MAX_NANOSECONDS => 1000000000;  # 1E9 = almost 32 bits
 use strict;
 
+use Scalar::Util 'blessed';
 require Exporter;
 our @ISA = qw/Exporter/;
 our @EXPORT_OK = qw/strpduration strfduration/;
@@ -53,7 +54,7 @@ sub base { croak("No arguments should be passed to base. Use set_base() instead.
 sub set_base {
     my $self = shift;
     my $newbase = shift;
-    croak("Argument to set_base() must be a DateTime object.") unless ref($newbase) eq 'DateTime';
+    croak("Argument to set_base() must be a DateTime object.") unless blessed($newbase) && $newbase->isa('DateTime');
     $self->{base} = $newbase;
     return $self;
 }
@@ -249,7 +250,7 @@ sub normalise {
             or not $self->base
         );
 
-    my %delta = (ref($_[0]) =~/^DateTime::Duration/)
+    my %delta = (blessed($_[0]) && $_[0]->isa('DateTime::Duration'))
         ? $_[0]->deltas
         : @_;
 
@@ -346,7 +347,7 @@ sub normalise {
 
 sub normalise_no_base {
     my $self = shift;
-    my %delta = (ref($_[0]) =~/^DateTime::Duration/) ? $_[0]->deltas : @_;
+    my %delta = (blessed($_[0]) && $_[0]->isa('DateTime::Duration')) ? $_[0]->deltas : @_;
 
     if (delete $delta{negative}) {
         foreach (keys %delta) { $delta{$_} *= -1 }

--- a/t/9_subclasses.t
+++ b/t/9_subclasses.t
@@ -1,0 +1,36 @@
+# Before `make install' is performed this script should be runnable with
+# `make test'. After `make install' it should work as `perl 1.t'
+
+package My::Datetime;
+use parent 'DateTime';
+
+package My::Duration;
+use parent 'DateTime::Duration';
+
+package main;
+use warnings;
+use DateTime::Format::Duration;
+
+use Test::More tests => 3;
+use Test::Fatal;
+
+my $dur = My::Duration->new( hours => 24, minutes => 60 );
+is(
+    DateTime::Format::Duration->new( pattern => '%P%F %r', normalize => 0 )->format_duration( $dur ),
+    '0000-00-00 00:1500:00',
+    'DateTime::Duration subclasses accepted without normalization',
+);
+is(
+    DateTime::Format::Duration->new( pattern => '%P%F %r', normalize => 'ISO' )->format_duration( $dur ),
+    '0000-00-01 01:00:00',
+    'DateTime::Duration subclasses accepted with normalization',
+);
+
+is(
+    exception {
+        my $fmt = DateTime::Format::Duration->new( pattern => '%P%F %r', normalize => 0 );
+        $fmt->set_base( My::Datetime->now );
+    },
+    undef,
+    "DateTime subclasses accepted as base"
+);


### PR DESCRIPTION
Subclassing `DateTime` and passing the object as a base would fail, as well as using subclasses of `DateTime::Duration` as objects to be formatted, because the module uses `ref` with a regex on the class name instead of `blessed` and `->isa`.
This PR adds `Scalar::Util` as a dependency (plus `Test::Fatal` at build time) so it won't work with Perl 5.6 any more but that should be fine by now ;)